### PR TITLE
Problem: no nonce for remote attestation report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,6 +3784,7 @@ dependencies = [
  "chrono",
  "cmac",
  "crypto-mac 0.8.0",
+ "hex",
  "log",
  "ra-common",
  "ra-sp-client",

--- a/chain-tx-enclave-next/enclave-ra/ra-common/src/sp/attestation_evidence.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-common/src/sp/attestation_evidence.rs
@@ -14,11 +14,11 @@ pub struct AttestationEvidence {
 
 impl AttestationEvidence {
     /// Creates attestation evidence from quote
-    pub fn from_quote(quote: &[u8]) -> Self {
+    pub fn from_quote(quote: &[u8], nonce: Option<String>) -> Self {
         Self {
             isv_enclave_quote: base64::encode(quote),
             pse_manifest: None,
-            nonce: None,
+            nonce,
         }
     }
 }

--- a/chain-tx-enclave-next/enclave-ra/ra-common/src/sp/protocol.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-common/src/sp/protocol.rs
@@ -10,7 +10,7 @@ pub enum Request {
     /// Generates a new quote from QE using AESM
     GetQuote { report: Vec<u8>, nonce: [u8; 16] },
     /// Generate attestation report using IAS
-    GetAttestationReport { quote: Vec<u8> },
+    GetAttestationReport { quote: Vec<u8>, ias_nonce: String },
 }
 
 /// Responses for request sent by enclave

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/Cargo.toml
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/Cargo.toml
@@ -12,6 +12,7 @@ aes = "0.4"
 chrono = "0.4"
 cmac = "0.3"
 crypto-mac = { version = "0.8", features = ["std"] }
+hex = "0.4"
 log = "0.4"
 rcgen = "0.8"
 ring = "0.16.15"

--- a/chain-tx-enclave-next/enclave-ra/ra-enclave/src/context.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-enclave/src/context.rs
@@ -118,8 +118,9 @@ impl EnclaveRaContext {
         verify_qe_report(&qe_report, &target_info, &quote, nonce)?;
 
         // Get attestation report from SP server
+        let ias_nonce = hex::encode(&get_random_nonce()?);
         self.sp_ra_client
-            .get_attestation_report(quote)
+            .get_attestation_report(quote, ias_nonce)
             .map_err(Into::into)
     }
 

--- a/chain-tx-enclave-next/enclave-ra/ra-sp-client/src/client.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-sp-client/src/client.rs
@@ -65,8 +65,9 @@ impl SpRaClient {
     pub fn get_attestation_report(
         &self,
         quote: Vec<u8>,
+        ias_nonce: String,
     ) -> Result<AttestationReport, SpRaClientError> {
-        let request = Request::GetAttestationReport { quote };
+        let request = Request::GetAttestationReport { quote, ias_nonce };
         serde_json::to_writer(&self.stream, &request)?;
 
         let response: Response = serde_json::Deserializer::from_reader(&self.stream)
@@ -92,4 +93,6 @@ pub enum SpRaClientError {
     NoResponse,
     #[error("Unexpected response: {0:?}")]
     UnexpectedResponse(Response),
+    #[error("{0}")]
+    Nonce(String),
 }

--- a/chain-tx-enclave-next/enclave-ra/ra-sp-client/src/lib.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-sp-client/src/lib.rs
@@ -13,11 +13,11 @@
 //!
 //! // Generate a enclave report using received target info
 //! let report = vec![];
-//!
-//! let quote_result = client.get_quote(report).unwrap();
+//! let nonce = [0; 16];
+//! let quote_result = client.get_quote(report, nonce).unwrap();
 //!
 //! // Verify the QE report in `quote_result`
-//! let attestation_report = client.get_attestation_report(quote_result.quote).unwrap();
+//! let attestation_report = client.get_attestation_report(quote_result.quote, nonce).unwrap();
 //! ```
 mod client;
 

--- a/chain-tx-enclave-next/enclave-ra/ra-sp-server/src/context.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-sp-server/src/context.rs
@@ -86,9 +86,13 @@ impl SpRaContext {
     }
 
     /// Verifies quote using IAS
-    pub fn verify_quote(&self, quote: &[u8]) -> Result<AttestationReport, SpRaContextError> {
+    pub fn verify_quote(
+        &self,
+        quote: &[u8],
+        ias_nonce: &str,
+    ) -> Result<AttestationReport, SpRaContextError> {
         self.ias_client
-            .verify_attestation_evidence(quote)
+            .verify_attestation_evidence(quote, ias_nonce)
             .map_err(Into::into)
     }
 }

--- a/chain-tx-enclave-next/enclave-ra/ra-sp-server/src/ias_client.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-sp-server/src/ias_client.rs
@@ -1,3 +1,4 @@
+use ra_common::AttestationReportBody;
 ///! FIXME: dead_code should disappear once this is started up in chain-abci / enclave
 ///! (pass SPID/ias_key to the enclave on the launch, but fixed URLs are at compile-time)
 use reqwest::blocking::Client;
@@ -81,8 +82,9 @@ impl IasClient {
     pub fn verify_attestation_evidence(
         &self,
         quote: &[u8],
+        ias_nonce: &str,
     ) -> Result<AttestationReport, IasClientError> {
-        let evidence = AttestationEvidence::from_quote(quote);
+        let evidence = AttestationEvidence::from_quote(quote, Some(ias_nonce.to_string()));
 
         let url = format!("{}{}", self.ias_base_uri, self.ias_report_path);
 
@@ -109,11 +111,18 @@ impl IasClient {
         // Parse attestation verification report body
         let body = response.bytes()?.to_vec();
 
-        Ok(AttestationReport {
-            body,
-            signature,
-            signing_cert,
-        })
+        // Validate nonce
+        let parsed_body: AttestationReportBody = serde_json::from_slice(&body)?;
+        let ret_nonce = parsed_body.nonce.ok_or(IasClientError::MissingNonce)?;
+        if ret_nonce == ias_nonce {
+            Ok(AttestationReport {
+                body,
+                signature,
+                signing_cert,
+            })
+        } else {
+            Err(IasClientError::InvalidNonce)
+        }
     }
 }
 
@@ -152,6 +161,10 @@ pub enum IasClientError {
     MissingSignature,
     #[error("Missing signing certificate in attestation verification report")]
     MissingSigningCertificate,
+    #[error("Missing nonce in attestation verification report")]
+    MissingNonce,
+    #[error("Invalid nonce in attestation verification report")]
+    InvalidNonce,
     #[error("Signing certificate decode error")]
     SigningCertificateDecodeError(#[source] std::str::Utf8Error),
 }

--- a/chain-tx-enclave-next/enclave-ra/ra-sp-server/src/server.rs
+++ b/chain-tx-enclave-next/enclave-ra/ra-sp-server/src/server.rs
@@ -68,8 +68,11 @@ fn handle_connection(context: &SpRaContext, stream: TcpStream) -> Result<(), SpR
 
                 Response::GetQuote { quote_result }
             }
-            Request::GetAttestationReport { ref quote } => {
-                let attestation_report = context.verify_quote(quote)?;
+            Request::GetAttestationReport {
+                ref quote,
+                ref ias_nonce,
+            } => {
+                let attestation_report = context.verify_quote(quote, ias_nonce)?;
 
                 Response::GetAttestationReport { attestation_report }
             }


### PR DESCRIPTION
This was an issue reported by kudelski. Intel claims that the nonce for remote attestation is optional, but I suppose it's better to be safer and include it.

@devashishdxt do you happen to know why it was left out? Maybe I am missing something, or it is truly unnecessary. Thanks

